### PR TITLE
Helper typo correction, change from clone to wallet

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -56,15 +56,15 @@ class App extends Component {
       this.setState({ networkId: networkId });
       this.setState({ chainId: chainId });
 
-
-      const ProxyWalletAddress = map.dev.ProxyWallet.toString();
+      //when brownie deploys contracts with helper, it drops in more addresses
+      const ProxyWalletAddress = map.dev.ProxyWallet[map.dev.ProxyWallet.length-1].toString(); 
       const ProxyWalletAbi = ProxyWallet.abi;
       const ProxyWalletInstance = new web3.eth.Contract(
         ProxyWalletAbi,
         ProxyWalletAddress,
       );
      
-      const FutureTokenAddress = map.dev.FutureToken.toString();
+      const FutureTokenAddress = map.dev.FutureToken[map.dev.FutureToken.length-1].toString();
       const FutureTokenAbi = FutureToken.abi;
       const FutureTokenInstance = new web3.eth.Contract(
         FutureTokenAbi,
@@ -83,31 +83,28 @@ class App extends Component {
 
       console.log('proxyWalletInstance: ' + ProxyWalletInstance);
       
-      //Goal is to create a clone contract instance
-      //this transaction gets or creates a clone.
-      //we should check if the userAccount already has a clone deployed
-      //declare a cloneAddress variable
-      var cloneAddress = '';
+      //Goal is to create a wallet contract instance
+      //this transaction gets or creates a wallet if needed.
+      //we should check if the userAccount already has a wallet deployed
+      //declare a walletAddress variable
+      var walletAddress = '';
       
       try {
         //try calling the getClone method. If there is no clone, then we will get an error
-        cloneAddress = await ProxyWalletInstance.methods.getClone().call({'from': userAccounts[0]});
+        walletAddress = await ProxyWalletInstance.methods.getWallet().call({'from': userAccounts[0]});
       }
         catch (error){
         //on the error, ask user to send a transaction creating a clone and console print the cloneAddress
-        cloneAddress= await ProxyWalletInstance.methods.getOrCreateClone().send({'from': userAccounts[0]});
+        walletAddress= await ProxyWalletInstance.methods.createWalletIfNeeded().send({'from': userAccounts[0]});
       }
-      console.log('clone address is : ' + cloneAddress);
-      //now we have the cloneAddress
-      //lets create a clone web3 contract instance that we can work with
-      //the cloneContract will have the same abi as the ProxyWalletInstance
-      const cloneContract = new web3.eth.Contract(
+      console.log('wallet address is : ' + walletAddress);
+      //now we have the walletAddress
+      //lets create a wallet web3 contract instance that we can work with
+      //the walletContract will have the same abi as the ProxyWalletInstance
+      const walletContract = new web3.eth.Contract(
         ProxyWalletAbi,
-        cloneAddress,
+        walletAddress,
       );
-      const check = await cloneContract.methods.proxyAddress().call();
-      console.log('proxywallet address is ' + ProxyWalletAddress);
-      console.log('proxyAddress of clone is ' + check.toString());
       
       //The goal here is to find out the futureClass Token expiry block
       //We will assume that the script has run and there is an exisiting expiry

--- a/scripts/helper.py
+++ b/scripts/helper.py
@@ -184,8 +184,8 @@ def main():
 
         # Create three proxy wallets for accounts 1 - 3
         PW1 = ProxyWallet.at(PW.createWalletIfNeeded({'from': accounts[1]}).return_value)
-        PW2 = ProxyWallet.at(PW.createWalletIfNeeded({'from': accounts[1]}).return_value)
-        PW3 = ProxyWallet.at(PW.createWalletIfNeeded({'from': accounts[1]}).return_value)
+        PW2 = ProxyWallet.at(PW.createWalletIfNeeded({'from': accounts[2]}).return_value)
+        PW3 = ProxyWallet.at(PW.createWalletIfNeeded({'from': accounts[3]}).return_value)
 
         # Buy $10,000, $50,000, and $100,000 of USDC into accounts 1 - 3
         for acct, amount in zip(accounts[1:4], (10000, 50000, 100000)):


### PR DESCRIPTION
When brownie runs, it deploys a bunch of contracts and now the map.json is different.
made changes to account for this. Updated function names to wallet etc vs clone.

Fixed the typos in helper.py (account[1] is used 3 times, instead of 1, 2, 3)